### PR TITLE
@dzucconi => Auto deploy travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: ruby
 rvm:
-  - 2.1.0
+- 2.1.5
 notifications:
   email:
     recipients:
-      - ilya@artsymail.com
+    - ilya@artsymail.com
     on_success: never
     on_failure: always
+script: bundle exec rake fspec
+deploy:
+  provider: heroku
+  api_key:
+    secure: GXevZgGpL2Bd7RbjypHC+PMCNNHERkZ086CHr66LNM4cNp5DRx9UW8pAhbv0tIN5XW54OLCVyyFSRuqM71qoxJ53QyGMrhNcihugWkNODY81lBtRSxAb6aNzH1Edt19iEfYbfPq2xc7YqaoNyPELgyGfpB85mm/1HNLZFgcjiV4=
+  app: sup-production
+  on:
+    repo: artsy/sup

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.1.0'
+ruby '2.1.5'
 source 'https://rubygems.org'
 
 gem 'rails', '4.1.8'


### PR DESCRIPTION
Let's see if it passes, but autodeploys and bumps ruby version to get rid of warnings:

```
warning: parser/current is loading parser/ruby21, which recognizes
warning: 2.1.5-compliant syntax, but you are running 2.1.0.
```
